### PR TITLE
AB#427886 - Refactor to remove if then else loop in parser-service

### DIFF
--- a/app/services/model-parsers.js
+++ b/app/services/model-parsers.js
@@ -1,0 +1,149 @@
+const asdaMatcher = require("./matchers/asda/model1");
+const asdaParser = require("./parsers/asda/model1");
+const asdaMatcher2 = require("./matchers/asda/model2");
+const asdaParser2 = require("./parsers/asda/model2");
+const bandMMatcher = require("./matchers/bandm/model1");
+const bandMParser = require("./parsers/bandm/model1");
+const buffaloadMatcher = require("./matchers/buffaload-logistics/model1");
+const buffaloadParser = require("./parsers/buffaload-logistics/model1");
+const cdsMatcher = require("./matchers/cds/model1");
+const cdsParser = require("./parsers/cds/model1");
+const coopMatcher = require("./matchers/co-op/model1");
+const coopParser = require("./parsers/co-op/model1");
+const davenportMatcher = require("./matchers/davenport/model1");
+const davenportParser = require("./parsers/davenport/model1");
+const fowlerWelchMatcher = require("./matchers/fowlerwelch/model1");
+const fowlerWelchParser = require("./parsers/fowlerwelch/model1");
+const giovanniMatcher = require("./matchers/giovanni/model1");
+const giovanniParser = require("./parsers/giovanni/model1");
+const kepakMatcher = require("./matchers/kepak/model1");
+const kepakParser = require("./parsers/kepak/model1");
+const nisaMatcher = require("./matchers/nisa/model1");
+const nisaParser = require("./parsers/nisa/model1");
+const nisaMatcher2 = require("./matchers/nisa/model2");
+const nisaParser2 = require("./parsers/nisa/model2");
+const nutriciaMatcher = require("./matchers/nutricia/model1");
+const nutriciaParser = require("./parsers/nutricia/model1");
+const sainsburysMatcher = require("./matchers/sainsburys/model1");
+const sainsburysParser = require("./parsers/sainsburys/model1");
+const tescosMatcher = require("./matchers/tescos/model1");
+const tescosParser = require("./parsers/tescos/model1");
+const tescosMatcher2 = require("./matchers/tescos/model2");
+const tescosParser2 = require("./parsers/tescos/model2");
+const tjMorrisMatcher = require("./matchers/tjmorris/model1");
+const tjMorrisParser = require("./parsers/tjmorris/model1");
+const warrensMatcher = require("./matchers/warrens/model1");
+const warrensParser = require("./parsers/warrens/model1");
+
+const parsersExcel = {
+  ASDA1: {
+    matches: (packingList, filename) =>
+      asdaMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      asdaParser.parse(packingList.PackingList_Extract, filename),
+  },
+  ASDA2: {
+    matches: (packingList, filename) =>
+      asdaMatcher2.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      asdaParser2.parse(packingList.Sheet1, filename),
+  },
+  BANDM1: {
+    matches: (packingList, filename) =>
+      bandMMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      bandMParser.parse(packingList.Sheet1, filename),
+  },
+  BUFFALOAD1: {
+    matches: (packingList, filename) =>
+      buffaloadMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      buffaloadParser.parse(packingList.Tabelle1, filename),
+  },
+  CDS1: {
+    matches: (packingList, filename) =>
+      cdsMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      cdsParser.parse(packingList[Object.keys(packingList)[0]], filename),
+  },
+  COOP1: {
+    matches: (packingList, filename) =>
+      coopMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      coopParser.parse(packingList["Input Packing Sheet"], filename),
+  },
+  DAVENPORT1: {
+    matches: (packingList, filename) =>
+      davenportMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      davenportParser.parse(packingList[Object.keys(packingList)[0]], filename),
+  },
+  FOWLERWELCH1: {
+    matches: (packingList, filename) =>
+      fowlerWelchMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      fowlerWelchParser.parse(packingList, filename),
+  },
+  GIOVANNI1: {
+    matches: (packingList, filename) =>
+      giovanniMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      giovanniParser.parse(packingList[Object.keys(packingList)[0]], filename),
+  },
+  KEPAK1: {
+    matches: (packingList, filename) =>
+      kepakMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      kepakParser.parse(packingList[Object.keys(packingList)[0]], filename),
+  },
+  NISA1: {
+    matches: (packingList, filename) =>
+      nisaMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      nisaParser.parse(packingList[Object.keys(packingList)[0]], filename),
+  },
+  NISA2: {
+    matches: (packingList, filename) =>
+      nisaMatcher2.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      nisaParser2.parse(packingList[Object.keys(packingList)[0]], filename),
+  },
+  NUTRICIA1: {
+    matches: (packingList, filename) =>
+      nutriciaMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      nutriciaParser.parse(packingList[Object.keys(packingList)[0]], filename),
+  },
+  SAINSBURYS1: {
+    matches: (packingList, filename) =>
+      sainsburysMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      sainsburysParser.parse(packingList.Sheet1, filename),
+  },
+  TESCO1: {
+    matches: (packingList, filename) =>
+      tescosMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      tescosParser.parse(packingList["Input Data Sheet"], filename),
+  },
+  TESCO2: {
+    matches: (packingList, filename) =>
+      tescosMatcher2.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      tescosParser2.parse(packingList.Sheet2, filename),
+  },
+  TJMORRIS1: {
+    matches: (packingList, filename) =>
+      tjMorrisMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      tjMorrisParser.parse(packingList.Sheet1, filename),
+  },
+  WARRENS1: {
+    matches: (packingList, filename) =>
+      warrensMatcher.matches(packingList, filename),
+    parse: (packingList, filename) =>
+      warrensParser.parse(packingList, filename),
+  },
+};
+
+module.exports = { parsersExcel };

--- a/app/services/parser-service.js
+++ b/app/services/parser-service.js
@@ -1,48 +1,12 @@
 const MatcherResult = require("./matcher-result");
 const ParserModel = require("./parser-model");
-const AsdaMatcher = require("./matchers/asda/model1");
-const AsdaParser = require("./parsers/asda/model1");
-const AsdaMatcher2 = require("./matchers/asda/model2");
-const AsdaParser2 = require("./parsers/asda/model2");
-const BandMMatcher = require("./matchers/bandm/model1");
-const BandMParser = require("./parsers/bandm/model1");
-const BuffaloadMatcher = require("./matchers/buffaload-logistics/model1");
-const BuffaloadParser = require("./parsers/buffaload-logistics/model1");
-const CoopMatcher = require("./matchers/co-op/model1");
-const CoopParser = require("./parsers/co-op/model1");
-const CdsMatcher = require("./matchers/cds/model1");
-const CdsParser = require("./parsers/cds/model1");
-const DavenportMatcher = require("./matchers/davenport/model1");
-const DavenportParser = require("./parsers/davenport/model1");
-const FowlerWelchMatcher = require("./matchers/fowlerwelch/model1");
-const FowlerWelchParser = require("./parsers/fowlerwelch/model1");
-const KepakMatcher = require("./matchers/kepak/model1");
-const KepakParser = require("./parsers/kepak/model1");
-const NisaMatcher = require("./matchers/nisa/model1");
-const NisaParser = require("./parsers/nisa/model1");
-const NisaMatcher2 = require("./matchers/nisa/model2");
-const NisaParser2 = require("./parsers/nisa/model2");
-const NutriciaMatcher = require("./matchers/nutricia/model1");
-const NutriciaParser = require("./parsers/nutricia/model1");
-const SainsburysMatcher = require("./matchers/sainsburys/model1");
-const SainsburysParser = require("./parsers/sainsburys/model1");
-const TescosMatcher = require("./matchers/tescos/model1");
-const TescosParser = require("./parsers/tescos/model1");
-const TescosMatcher2 = require("./matchers/tescos/model2");
-const TescosParser2 = require("./parsers/tescos/model2");
-const TjMorrisMatcher = require("./matchers/tjmorris/model1");
-const TjMorrisParser = require("./parsers/tjmorris/model1");
-const GiovanniMatcher = require("./matchers/giovanni/model1");
-const GiovanniParser = require("./parsers/giovanni/model1");
-const WarrensMatcher = require("./matchers/warrens/model1");
-const WarrensParser = require("./parsers/warrens/model1");
 const CombineParser = require("./parser-combine");
 const JsonFile = require("../utilities/json-file");
 const FileExtension = require("../utilities/file-extension");
-
-const INPUT_DATA_SHEET = "Input Data Sheet";
+const { parsersExcel } = require("./model-parsers");
 
 const isNullOrUndefined = (value) => value === null || value === undefined;
+
 function findParser(packingList, filename) {
   let parsedPackingList = failedParser();
 
@@ -52,119 +16,19 @@ function findParser(packingList, filename) {
   const sanitisedPackingList = JSON.parse(sanitisedPackingListJson);
   // Test for Excel spreadsheets
   if (FileExtension.isExcel(filename)) {
-    if (
-      TjMorrisMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = TjMorrisParser.parse(sanitisedPackingList.Sheet1);
-    } else if (
-      AsdaMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = AsdaParser.parse(
-        sanitisedPackingList.PackingList_Extract,
-      );
-    } else if (
-      AsdaMatcher2.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = AsdaParser2.parse(sanitisedPackingList.Sheet1);
-    } else if (
-      SainsburysMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = SainsburysParser.parse(sanitisedPackingList.Sheet1);
-    } else if (
-      BandMMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = BandMParser.parse(sanitisedPackingList.Sheet1);
-      isParsed = true;
-    } else if (
-      CoopMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = CoopParser.parse(
-        sanitisedPackingList["Input Packing Sheet"],
-      );
-    } else if (
-      TescosMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = TescosParser.parse(
-        sanitisedPackingList[INPUT_DATA_SHEET],
-      );
-    } else if (
-      TescosMatcher2.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = TescosParser2.parse(sanitisedPackingList.Sheet2);
-    } else if (
-      FowlerWelchMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = FowlerWelchParser.parse(sanitisedPackingList);
-    } else if (
-      NisaMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = NisaParser.parse(
-        sanitisedPackingList[Object.keys(sanitisedPackingList)[0]],
-      );
-    } else if (
-      NisaMatcher2.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = NisaParser2.parse(
-        sanitisedPackingList[Object.keys(sanitisedPackingList)[0]],
-      );
-    } else if (
-      BuffaloadMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = BuffaloadParser.parse(sanitisedPackingList.Tabelle1);
-      isParsed = true;
-    } else if (
-      CdsMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = CdsParser.parse(
-        sanitisedPackingList[Object.keys(sanitisedPackingList)[0]],
-      );
-    } else if (
-      DavenportMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = DavenportParser.parse(
-        sanitisedPackingList[Object.keys(sanitisedPackingList)[0]],
-      );
-    } else if (
-      GiovanniMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = GiovanniParser.parse(
-        sanitisedPackingList[Object.keys(sanitisedPackingList)[0]],
-      );
-    } else if (
-      KepakMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = KepakParser.parse(
-        sanitisedPackingList[Object.keys(sanitisedPackingList)[0]],
-      );
-    } else if (
-      NutriciaMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = NutriciaParser.parse(
-        sanitisedPackingList[Object.keys(sanitisedPackingList)[0]],
-      );
-    } else if (
-      WarrensMatcher.matches(sanitisedPackingList, filename) ===
-      MatcherResult.CORRECT
-    ) {
-      parsedPackingList = WarrensParser.parse(sanitisedPackingList);
-    } else {
+    Object.keys(parsersExcel).forEach((key) => {
+      if (
+        parsersExcel[key].matches(sanitisedPackingList, filename) ===
+        MatcherResult.CORRECT
+      ) {
+        parsedPackingList = parsersExcel[key].parse(
+          sanitisedPackingList,
+          filename,
+        );
+      }
+    });
+
+    if (parsedPackingList != failedParser()) {
       console.info("Failed to parse packing list with filename: ", filename);
     }
   } else {

--- a/app/services/parser-service.js
+++ b/app/services/parser-service.js
@@ -9,6 +9,7 @@ const isNullOrUndefined = (value) => value === null || value === undefined;
 
 function findParser(packingList, filename) {
   let parsedPackingList = failedParser();
+  let parserFound = false;
 
   // Sanitised packing list (i.e. emove trailing spaces and empty cells)
   const packingListJson = JSON.stringify(packingList);
@@ -21,6 +22,7 @@ function findParser(packingList, filename) {
         parsersExcel[key].matches(sanitisedPackingList, filename) ===
         MatcherResult.CORRECT
       ) {
+        parserFound = true;
         parsedPackingList = parsersExcel[key].parse(
           sanitisedPackingList,
           filename,
@@ -28,7 +30,7 @@ function findParser(packingList, filename) {
       }
     });
 
-    if (parsedPackingList != failedParser()) {
+    if (!parserFound) {
       console.info("Failed to parse packing list with filename: ", filename);
     }
   } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade-exportscore-plp",
-  "version": "3.0.21",
+  "version": "3.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade-exportscore-plp",
-      "version": "3.0.21",
+      "version": "3.0.22",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade-exportscore-plp",
-  "version": "3.0.21",
+  "version": "3.0.22",
   "description": "",
   "homepage": "github.com?owner=defra&repo=trade-exportscore-plp&organization=defra",
   "main": "app/index.js",


### PR DESCRIPTION
# Pull Request Details

## What this PR does / why we need it:

- _Add model-parsers module that contains promises to matchers and parsers_
- _Refactor to remove if then else loop in parser-service by looping through model-parsers module properties_

## Special notes for your reviewer

_None_

## Testing

_Run unit test and samples of PLs_