### PR TITLE
AB#487486 corrected problem recognising invalid rows

### DIFF
--- a/app/services/validators/packing-list-column-validator.js
+++ b/app/services/validators/packing-list-column-validator.js
@@ -39,7 +39,9 @@ function validatePackingListByIndexAndType(packingList) {
       missingIdentifier.length === 0 &&
       missingDescription.length === 0 &&
       missingPackages.length === 0 &&
+      invalidPackages.length === 0 &&
       missingNetWeight.length === 0 &&
+      invalidNetWeight.length === 0 &&
       hasRemos &&
       !isEmpty,
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade-exportscore-plp",
-  "version": "6.3.3",
+  "version": "6.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade-exportscore-plp",
-      "version": "6.3.3",
+      "version": "6.3.4",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/ai-form-recognizer": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade-exportscore-plp",
-  "version": "6.3.3",
+  "version": "6.3.4",
   "description": "",
   "homepage": "github.com?owner=defra&repo=trade-exportscore-plp&organization=defra",
   "main": "app/index.js",

--- a/test/unit/services/validators/packing-list-column-validator.test.js
+++ b/test/unit/services/validators/packing-list-column-validator.test.js
@@ -57,6 +57,8 @@ describe("validatePackingListByIndexAndType", () => {
     expect(result.missingDescription.length).toBe(0);
     expect(result.missingPackages.length).toBe(0);
     expect(result.missingNetWeight.length).toBe(0);
+    expect(result.invalidPackages.length).toBe(0);
+    expect(result.invalidNetWeight.length).toBe(0);
     expect(result.hasRemos).toBeFalsy();
     expect(result.isEmpty).toBeFalsy();
   });
@@ -87,6 +89,8 @@ describe("validatePackingListByIndexAndType", () => {
     expect(result.missingDescription.length).toBe(0);
     expect(result.missingPackages.length).toBe(0);
     expect(result.missingNetWeight.length).toBe(0);
+    expect(result.invalidPackages.length).toBe(0);
+    expect(result.invalidNetWeight.length).toBe(0);
     expect(result.hasRemos).toBeTruthy();
     expect(result.isEmpty).toBeFalsy();
   });
@@ -117,6 +121,8 @@ describe("validatePackingListByIndexAndType", () => {
     expect(result.missingDescription.length).toBe(0);
     expect(result.missingPackages.length).toBe(0);
     expect(result.missingNetWeight.length).toBe(0);
+    expect(result.invalidPackages.length).toBe(0);
+    expect(result.invalidNetWeight.length).toBe(0);
     expect(result.hasRemos).toBeTruthy();
     expect(result.isEmpty).toBeFalsy();
   });
@@ -147,6 +153,8 @@ describe("validatePackingListByIndexAndType", () => {
     expect(result.missingDescription.length).toBe(0);
     expect(result.missingPackages.length).toBe(0);
     expect(result.missingNetWeight.length).toBe(0);
+    expect(result.invalidPackages.length).toBe(0);
+    expect(result.invalidNetWeight.length).toBe(0);
     expect(result.hasRemos).toBeTruthy();
     expect(result.isEmpty).toBeFalsy();
   });
@@ -207,6 +215,8 @@ describe("validatePackingListByIndexAndType", () => {
     expect(result.missingDescription.length).toBe(0);
     expect(result.missingPackages.length).toBe(1);
     expect(result.missingNetWeight.length).toBe(0);
+    expect(result.invalidPackages.length).toBe(0);
+    expect(result.invalidNetWeight.length).toBe(0);
     expect(result.hasRemos).toBeTruthy();
     expect(result.isEmpty).toBeFalsy();
   });
@@ -237,6 +247,72 @@ describe("validatePackingListByIndexAndType", () => {
     expect(result.missingDescription.length).toBe(0);
     expect(result.missingPackages.length).toBe(0);
     expect(result.missingNetWeight.length).toBe(1);
+    expect(result.invalidPackages.length).toBe(0);
+    expect(result.invalidNetWeight.length).toBe(0);
+    expect(result.hasRemos).toBeTruthy();
+    expect(result.isEmpty).toBeFalsy();
+  });
+
+  test("invalid packages", () => {
+    const packingList = {
+      registration_approval_number: "remos",
+      items: [
+        {
+          description: "description",
+          nature_of_products: "nature of products",
+          type_of_treatment: "treatment type",
+          commodity_code: "123",
+          number_of_packages: "potato",
+          total_net_weight_kg: 1.2,
+        },
+      ],
+      business_checks: {
+        all_required_fields_present: true,
+      },
+    };
+
+    const result =
+      packingListValidator.validatePackingListByIndexAndType(packingList);
+
+    expect(result.hasAllFields).toBeFalsy();
+    expect(result.missingIdentifier.length).toBe(0);
+    expect(result.missingDescription.length).toBe(0);
+    expect(result.missingPackages.length).toBe(0);
+    expect(result.missingNetWeight.length).toBe(0);
+    expect(result.invalidPackages.length).toBe(1);
+    expect(result.invalidNetWeight.length).toBe(0);
+    expect(result.hasRemos).toBeTruthy();
+    expect(result.isEmpty).toBeFalsy();
+  });
+
+  test("invalid net weight", () => {
+    const packingList = {
+      registration_approval_number: "remos",
+      items: [
+        {
+          description: "description",
+          nature_of_products: "nature of products",
+          type_of_treatment: "treatment type",
+          commodity_code: "123",
+          number_of_packages: 1,
+          total_net_weight_kg: "potato",
+        },
+      ],
+      business_checks: {
+        all_required_fields_present: true,
+      },
+    };
+
+    const result =
+      packingListValidator.validatePackingListByIndexAndType(packingList);
+
+    expect(result.hasAllFields).toBeFalsy();
+    expect(result.missingIdentifier.length).toBe(0);
+    expect(result.missingDescription.length).toBe(0);
+    expect(result.missingPackages.length).toBe(0);
+    expect(result.missingNetWeight.length).toBe(0);
+    expect(result.invalidPackages.length).toBe(0);
+    expect(result.invalidNetWeight.length).toBe(1);
     expect(result.hasRemos).toBeTruthy();
     expect(result.isEmpty).toBeFalsy();
   });
@@ -283,6 +359,8 @@ describe("validatePackingListByIndexAndType", () => {
     expect(result.missingDescription.length).toBe(0);
     expect(result.missingPackages.length).toBe(0);
     expect(result.missingNetWeight.length).toBe(1);
+    expect(result.invalidPackages.length).toBe(1);
+    expect(result.invalidNetWeight.length).toBe(1);
     expect(result.hasRemos).toBeTruthy();
     expect(result.isEmpty).toBeFalsy();
   });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<AB#213700>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. AB#213700 (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# Pull Request Details

## What this PR does / why we need it:
 Buffaload packing list was highlighting that invalid characters were not being treated if failures if they were the only problem.  This has been corrected.  Linked to [AB#487486](https://dev.azure.com/defragovuk/0007dd9e-c7cf-473a-a859-4aad7bd32c5e/_workitems/edit/487486)