### PR TITLE
AB#540968: Bug/540968 booker volume field

### DIFF
--- a/app/services/model-headers.js
+++ b/app/services/model-headers.js
@@ -362,7 +362,7 @@ const headers = {
       total_net_weight_kg: {
         x: /Net/i,
         x1: 420,
-        x2: 450,
+        x2: 445,
         regex: /Net Weight \(Kilos\)/i,
       },
       type_of_treatment: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade-exportscore-plp",
-  "version": "6.10.3",
+  "version": "6.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade-exportscore-plp",
-      "version": "6.10.3",
+      "version": "6.10.4",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/ai-form-recognizer": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade-exportscore-plp",
-  "version": "6.10.3",
+  "version": "6.10.4",
   "description": "",
   "homepage": "github.com?owner=defra&repo=trade-exportscore-plp&organization=defra",
   "main": "app/index.js",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<AB#213700>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. AB#213700 (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# Pull Request Details
changed x2 value for net weight column
## What this PR does / why we need it:
Change in x2 for net weight column will no longer include values from the volume column
_A brief description of changes being made_
Relates to ADO Work Item [AB#540968](https://dev.azure.com/defragovuk/0007dd9e-c7cf-473a-a859-4aad7bd32c5e/_workitems/edit/540968) 

## Special notes for your reviewer

_Any specific actions or notes on review?_

## Testing

_Any relevant testing information and pipeline runs._

## Checklist (please delete before completing or setting auto-complete)

- [ ] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [ ] Title pattern should be `{work item number}: {title}`
- [ ] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests
- [ ] If the PR includes a new parser, please ensure the happy & unhappy path test files are linked to [this](https://eaflood.atlassian.net/wiki/spaces/EX/pages/4855562467/Packing+List+analysis#Top-20-Traders) page and the detailed description is added to [this](https://eaflood.atlassian.net/wiki/spaces/EX/pages/4855562467/Packing+List+analysis) page. Thanks

## How does this PR make you feel:

![gif]([https://giphy.com/)
