### PR TITLE
filter out drag down rows for Kepak

### DIFF
--- a/app/services/parsers/kepak/model1.js
+++ b/app/services/parsers/kepak/model1.js
@@ -28,6 +28,15 @@ function parse(packingListJson) {
       packingListJson[sheets[0]],
     );
 
+    const notDragDownCallback = function (item) {
+      return !(
+        item.description === 0 &&
+        item.commodity_code === 0 &&
+        item.number_of_packages === 0 &&
+        item.total_net_weight_kg === 0
+      );
+    };
+
     for (const sheet of sheets) {
       establishmentNumbers = regex.findAllMatches(
         regex.remosRegex,
@@ -42,6 +51,10 @@ function parse(packingListJson) {
         headers.KEPAK1,
         sheet,
       );
+
+      packingListContentsTemp =
+        packingListContentsTemp.filter(notDragDownCallback);
+
       packingListContents = packingListContents.concat(packingListContentsTemp);
     }
 

--- a/test/unit/services/parsers/kepak/model1.test.js
+++ b/test/unit/services/parsers/kepak/model1.test.js
@@ -16,6 +16,12 @@ describe("parseKepakModel1", () => {
     expect(result).toMatchObject(test_results.validTestResultForMultipleSheets);
   });
 
+  test("parses valid json with dragdown", () => {
+    const result = parser.parse(model.validModelWithDragdown);
+
+    expect(result).toMatchObject(test_results.validTestResult);
+  });
+
   test("parses empty json", () => {
     const result = parser.parse(model.emptyModel);
 

--- a/test/unit/test-data-and-results/models/kepak/model1.js
+++ b/test/unit/test-data-and-results/models/kepak/model1.js
@@ -1,3 +1,5 @@
+const { validModelWithDragdown } = require("../fowlerwelch/model1");
+
 module.exports = {
   validModel: {
     KEPAK: [
@@ -41,6 +43,58 @@ module.exports = {
         F: "GB",
         G: 22,
         H: 27.632,
+      },
+    ],
+  },
+  validModelWithDragdown: {
+    KEPAK: [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      { I: "RMS-GB-000149-005" },
+      {},
+      { A: "RMS-GB-000280" },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        C: "DESCRIPTION",
+        E: "Commodity Code",
+        F: "Country of Origin",
+        G: "Quantity",
+        H: "Net Weight (KG)",
+      },
+      {
+        C: "RS DOUBLE DECKER STD",
+        E: "1602509590",
+        F: "GB",
+        G: 32,
+        H: 30.336,
+      },
+      {
+        C: "RS BBQ RIB STD 8X157G",
+        E: "1602493000",
+        F: "GB",
+        G: 22,
+        H: 27.632,
+      },
+      {
+        C: 0,
+        E: 0,
+        F: 0,
+        G: 0,
+        H: 0,
       },
     ],
   },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<AB#213700>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. AB#213700 (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# Pull Request Details

## What this PR does / why we need it:

The packing list contains rows made up of 0s which cause it to fail.  They are now filtered out to allow processing to work
[AB#576720](https://dev.azure.com/defragovuk/0007dd9e-c7cf-473a-a859-4aad7bd32c5e/_workitems/edit/576720)

## Special notes for your reviewer

_Any specific actions or notes on review?_

## Testing

_Any relevant testing information and pipeline runs._

## Checklist (please delete before completing or setting auto-complete)

- [ ] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [ ] Title pattern should be `{work item number}: {title}`
- [ ] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests
- [ ] If the PR includes a new parser, please ensure the happy & unhappy path test files are linked to [this](https://eaflood.atlassian.net/wiki/spaces/EX/pages/4855562467/Packing+List+analysis#Top-20-Traders) page and the detailed description is added to [this](https://eaflood.atlassian.net/wiki/spaces/EX/pages/4855562467/Packing+List+analysis) page. Thanks

## How does this PR make you feel:

![gif]([https://giphy.com/)
